### PR TITLE
Make README example more sensible

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ Usage
 ```
     from btfxwss import BtfxWss
     
-    logging.basicConfig(level=logging.DEBUG, filename='test.log')
     log = logging.getLogger(__name__)
 
     fh = logging.FileHandler('test.log')
@@ -40,10 +39,13 @@ Usage
 
     log.addHandler(sh)
     log.addHandler(fh)
+    logging.basicConfig(level=logging.DEBUG, handlers=[fh, sh])
     
     wss = BtfxWss()
     wss.start()
-    time.sleep(1)  # give the client some prep time to set itself up.
+    
+    # Wait (indefinitely) for the websocket connection to happen.
+    wss.conn.wait():
     
     # Subscribe to some channels
     wss.subscribe_to_ticker('BTCUSD')

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ pip install btfxwss
 Usage
 =====
 
-```
+```python
     from btfxwss import BtfxWss
     
     log = logging.getLogger(__name__)


### PR DESCRIPTION
For me, 1s was not enough for the connection to establish, and the error I got (`KeyError: ('ticker', 'BTCUSD')` was very obscure. Also, not seeing anything on stdout, I didn't think of checking `test.log` because the code *seems* to make them equal, but doesn't.

This fixes both: 1) actually wait until the connection event happens, and 2) actually make logging go to both stdout and `test.log`.