### PR TITLE
Added support for new/update/cancel position channels

### DIFF
--- a/btfxwss/client.py
+++ b/btfxwss/client.py
@@ -114,6 +114,78 @@ class BtfxWss:
         :return: Queue()
         """
         return self.queue_processor.account['Position Cancel']
+    
+    @property
+    def funding_offer_new(self):
+        """Return queue containing new funding offers associated with the user account.
+
+        :return: Queue()
+        """
+        return self.queue_processor.account['Funding Offer New']
+    
+    @property
+    def funding_offer_update(self):
+        """Return queue containing funding offer updates associated with the user account.
+
+        :return: Queue()
+        """
+        return self.queue_processor.account['Funding Offer Update']
+    
+    @property
+    def funding_offer_cancel(self):
+        """Return queue containing canceled funding offers associated with the user account.
+
+        :return: Queue()
+        """
+        return self.queue_processor.account['Funding Offer Cancel']
+    
+    @property
+    def funding_credit_new(self):
+        """Return queue containing new funding credit associated with the user account.
+
+        :return: Queue()
+        """
+        return self.queue_processor.account['Funding Credit New']
+    
+    @property
+    def funding_credit_update(self):
+        """Return queue containing funding credit updates associated with the user account.
+
+        :return: Queue()
+        """
+        return self.queue_processor.account['Funding Credit Update']
+    
+    @property
+    def funding_credit_cancel(self):
+        """Return queue containing canceled funding credit associated with the user account.
+
+        :return: Queue()
+        """
+        return self.queue_processor.account['Funding Credit Cancel']
+    
+    @property
+    def funding_loan_new(self):
+        """Return queue containing new funding loan associated with the user account.
+
+        :return: Queue()
+        """
+        return self.queue_processor.account['Funding Loan New']
+    
+    @property
+    def funding_loan_update(self):
+        """Return queue containing funding loan updates associated with the user account.
+
+        :return: Queue()
+        """
+        return self.queue_processor.account['Funding Loan Update']
+    
+    @property
+    def funding_loan_cancel(self):
+        """Return queue containing canceled funding loan associated with the user account.
+
+        :return: Queue()
+        """
+        return self.queue_processor.account['Funding Loan Cancel']
 
     @property
     def transactions(self):

--- a/btfxwss/client.py
+++ b/btfxwss/client.py
@@ -116,14 +116,6 @@ class BtfxWss:
         return self.queue_processor.account['Position Cancel']
 
     @property
-    def historical_orders(self):
-        """Return history of orders associated with the user account.
-
-        :return: Queue()
-        """
-        return self.queue_processor.account['Historical Orders']
-
-    @property
     def transactions(self):
         """Return history of trades associated with the user account.
 
@@ -138,15 +130,7 @@ class BtfxWss:
         :return: Queue()
         """
         return self.queue_processor.account['Loans']
-
-    @property
-    def historical_loans(self):
-        """Return history of loans associated with the user account.
-
-        :return: Queue()
-        """
-        return self.queue_processor.account['Historical Loans']
-
+    
     @property
     def wallets(self):
         """Return wallet balances associated with the user account.
@@ -180,14 +164,6 @@ class BtfxWss:
         return self.queue_processor.account['Offers']
 
     @property
-    def historical_offers(self):
-        """Return history of offers associated with the user account.
-
-        :return: Queue()
-        """
-        return self.queue_processor.account['Historical Offers']
-
-    @property
     def funding_info(self):
         """Return funding information associated with the user account.
 
@@ -202,14 +178,6 @@ class BtfxWss:
         :return: Queue()
         """
         return self.queue_processor.account['Credits']
-
-    @property
-    def historical_credits(self):
-        """Return history of credits associated with the user account.
-
-        :return: Queue()
-        """
-        return self.queue_processor.account['Historical Credits']
 
     @property
     def channel_directory(self):
@@ -234,6 +202,38 @@ class BtfxWss:
         :return: Queue()
         """
         return self.queue_processor.account['Notifications']
+    
+    # DEPRECATED FUNCTIONS
+    @property
+    def historical_credits(self):
+        """Return history of credits associated with the user account.
+
+        :return: Queue()
+        """
+        return self.queue_processor.account['Historical Credits']
+    
+    @property
+    def historical_offers(self):
+        """Return history of offers associated with the user account.
+
+        :return: Queue()
+        """
+        return self.queue_processor.account['Historical Offers']
+    
+    @property
+    def historical_loans(self):
+        """Return history of loans associated with the user account.
+
+        :return: Queue()
+        """
+        return self.queue_processor.account['Historical Loans']
+    @property
+    def historical_orders(self):
+        """Return history of orders associated with the user account.
+
+        :return: Queue()
+        """
+        return self.queue_processor.account['Historical Orders']
 
     ##############################################
     # Client Initialization and Shutdown Methods #

--- a/btfxwss/client.py
+++ b/btfxwss/client.py
@@ -90,6 +90,30 @@ class BtfxWss:
         :return: Queue()
         """
         return self.queue_processor.account['Positions']
+    
+    @property
+    def positions_new(self):
+        """Return queue containing new positions associated with the user account.
+
+        :return: Queue()
+        """
+        return self.queue_processor.account['Position New']
+
+    @property
+    def positions_update(self):
+        """Return queue containing position updates associated with the user account.
+
+        :return: Queue()
+        """
+        return self.queue_processor.account['Position Update']
+
+    @property
+    def positions_cancel(self):
+        """Return queue containing position cancellations associated with the user account.
+
+        :return: Queue()
+        """
+        return self.queue_processor.account['Position Cancel']
 
     @property
     def historical_orders(self):

--- a/btfxwss/queue_processor.py
+++ b/btfxwss/queue_processor.py
@@ -83,7 +83,7 @@ class QueueProcessor(Thread):
                                       'hfcs': 'Historical Credits',
                                       'hfls': 'Historical Loans',
                                       'htfs': 'Funding Trades',
-                                      'n': 'Notifications',
+                                      'n': 'Notifications', 'ats': 'ATS',
                                       'on': 'Order New', 'ou': 'Order Update', 'oc': 'Order Cancel',
                                       'pn': 'Position New', 'pu': 'Position Update', 'pc': 'Position Cancel',
                                       'fon': 'Funding Offer New', 'fou': 'Funding Offer Update', 'foc': 'Funding Offer Cancel',

--- a/btfxwss/queue_processor.py
+++ b/btfxwss/queue_processor.py
@@ -86,7 +86,10 @@ class QueueProcessor(Thread):
                                       'n': 'Notifications',
                                       'on': 'Order New',
                                       'ou': 'Order Update',
-                                      'oc': 'Order Cancel'}
+                                      'oc': 'Order Cancel',
+                                      'pn': 'Position New',
+                                      'pu': 'Position Update',
+                                      'pc': 'Position Cancel'}
 
     def join(self, timeout=None):
         """Set sentinel for run() method and join thread.

--- a/btfxwss/queue_processor.py
+++ b/btfxwss/queue_processor.py
@@ -79,17 +79,16 @@ class QueueProcessor(Thread):
                                       'wu': 'Wallets',
                                       'miu': 'Margin Info', 'fos': 'Offers',
                                       'fiu': 'Funding Info',  'fcs': 'Credits',
-                                      'hfos': 'Historical Offers',
+                                      'hfos': 'Historical Offers', 
                                       'hfcs': 'Historical Credits',
                                       'hfls': 'Historical Loans',
                                       'htfs': 'Funding Trades',
                                       'n': 'Notifications',
-                                      'on': 'Order New',
-                                      'ou': 'Order Update',
-                                      'oc': 'Order Cancel',
-                                      'pn': 'Position New',
-                                      'pu': 'Position Update',
-                                      'pc': 'Position Cancel'}
+                                      'on': 'Order New', 'ou': 'Order Update', 'oc': 'Order Cancel',
+                                      'pn': 'Position New', 'pu': 'Position Update', 'pc': 'Position Cancel',
+                                      'fon': 'Funding Offer New', 'fou': 'Funding Offer Update', 'foc': 'Funding Offer Cancel',
+                                      'fcn': 'Funding Credit New', 'fcu': 'Funding Credit Update', 'fcc': 'Funding Offer Cancel',
+                                      'fln': 'Funding Loan New', 'flu': 'Funding Loan Update', 'flc': 'Funding Loan Cancel'}
 
     def join(self, timeout=None):
         """Set sentinel for run() method and join thread.


### PR DESCRIPTION
Ran into an issue where pu/pn/pc gave 'Channel ID does not have data handler', found out it was not implemented yet. It is a trivial enough addition that I thought it might make sense to immediately deploy it to the release but I am not sure what your workflow is yet, so I made the changes to the dev branch.