### PR TITLE
fix _send_auth_command function to send keys and set auth=True

### DIFF
--- a/btfxwss/client.py
+++ b/btfxwss/client.py
@@ -639,4 +639,4 @@ class BtfxWss:
 
     def _send_auth_command(self, channel_name, data):
         payload = [0, channel_name, None, data]
-        self.conn.send(list_data=payload)
+        self.conn.send(list_data=payload, auth = True, api_key = self.key, secret = self.secret)


### PR DESCRIPTION
send function is not sending as a auth method when called by _send_auth_command function.