### PR TITLE
Ensure code key is set on the data dictionary to prevent errors during execution

### DIFF
--- a/btfxwss/connection.py
+++ b/btfxwss/connection.py
@@ -397,8 +397,9 @@ class WebSocketConnection(Thread):
         codes = {'20051': self.reconnect, '20060': self._pause,
                  '20061': self._unpause}
         try:
-            self.log.info(info_message[data['code']])
-            codes[data['code']]()
+            if 'code' in data:
+                self.log.info(info_message[data['code']])
+                codes[data['code']]()
         except KeyError as e:
             self.log.exception(e)
             self.log.error("Unknown Info code %s!", data['code'])


### PR DESCRIPTION
### Overview Description 

There are cases where new codes may be added to the API and they will be added to the info_message dictionary; however, there is a case where the 'code' key is not set at all on the data dictionary. This problem happens at first execution of running the example code.

# Steps to Reproduce

1. Instantiate a fresh Amazon Linux AMI 2017.09.1
2. Install Python & Pip 3.6.2
```
sudo yum install python36 -y
sudo yum install python36-pip -y
```
3. Install btfxwss
```
pip install btfxwss
```
4. Execute the code from the readme [example](https://github.com/nlsdfnbch/btfxwss#usage)

# Actual Results
```
[ec2-user@ip-192-168-1-1 ~]$ python36 btfxwss-example.py
INFO:btfxwss.connection:Connection opened
ERROR:btfxwss.connection:'code'
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/btfxwss/connection.py", line 400, in _info_handler
    self.log.info(info_message[data['code']])
KeyError: 'code'
ERROR:websocket:error from callback <bound method WebSocketConnection._on_message of <WebSocketConnection(Thread-1, started daemon 140025468729088)>>: 'code'
  File "/usr/local/lib/python3.6/site-packages/websocket/_app.py", line 269, in _callback
    callback(self, *args)
  File "/usr/local/lib/python3.6/site-packages/btfxwss/connection.py", line 169, in _on_message
    self._system_handler(data, received_at)
  File "/usr/local/lib/python3.6/site-packages/btfxwss/connection.py", line 359, in _system_handler
    self._info_handler(data)
  File "/usr/local/lib/python3.6/site-packages/btfxwss/connection.py", line 404, in _info_handler
    self.log.error("Unknown Info code %s!", data['code'])
DEBUG:btfxwss.client:_subscribe: {'event': 'subscribe', 'channel': 'ticker', 'symbol': 'BTCUSD'}
DEBUG:btfxwss.client:_subscribe: {'event': 'subscribe', 'channel': 'book', 'symbol': 'BTCUSD'}
INFO:btfxwss.queue_processor:Subscription succesful for channel ('ticker', 'BTCUSD')
INFO:btfxwss.queue_processor:Subscription succesful for channel ('book', 'BTCUSD')
([[16106, 43.4417526, 16107, 28.49714496, 2320, 0.1684, 16100, 145958.73957214, 17171, 13553]], 1512707359.3610623)
([[16100, 47.51947402, 16105, 30.9635016, 2324, 0.1687, 16104, 145964.53218071, 17171, 13553]], 1512707366.931447)
```
# Expected Results
```
[ec2-user@ip-192-168-1-1 ~]$ python36 btfxwss-example.py
INFO:btfxwss.connection:Connection opened
DEBUG:btfxwss.client:_subscribe: {'event': 'subscribe', 'channel': 'ticker', 'symbol': 'BTCUSD'}
DEBUG:btfxwss.client:_subscribe: {'event': 'subscribe', 'channel': 'book', 'symbol': 'BTCUSD'}
INFO:btfxwss.queue_processor:Subscription succesful for channel ('ticker', 'BTCUSD')
INFO:btfxwss.queue_processor:Subscription succesful for channel ('book', 'BTCUSD')
([[15747, 88.89462703, 15761, 49.35526551, 1923, 0.139, 15761, 147296.76900499, 17171, 13553]], 1512708410.4174225)
([[15758, 89.75378014, 15759, 55.44152101, 1920, 0.1387, 15758, 147302.4401364, 17171, 13553]], 1512708417.4354184)
```
# Reproducibility
Every time the steps above are taken.

# Additional Information:
None.