### PR TITLE
Support version message in _info_handler function. Solve #98.

### DIFF
--- a/btfxwss/connection.py
+++ b/btfxwss/connection.py
@@ -396,6 +396,11 @@ class WebSocketConnection(Thread):
 
         codes = {'20051': self.reconnect, '20060': self._pause,
                  '20061': self._unpause}
+
+        if 'version' in data:
+            self.log.info("API version: %i", data['version'])
+            return
+
         try:
             self.log.info(info_message[data['code']])
             codes[data['code']]()


### PR DESCRIPTION
Reading the [documentation](https://docs.bitfinex.com/docs/ws-general) I found the first message contains the actual version of the websocket stream.

The expected message is:

```
{
   "event":"info",
   "version": 1
}
```

The patch check if the message have the 'version' key in the message, log the version and exit the function.